### PR TITLE
Requires item presence unless comments are written in partner request

### DIFF
--- a/app/models/partner_request.rb
+++ b/app/models/partner_request.rb
@@ -3,6 +3,7 @@ class PartnerRequest < ApplicationRecord
 
   has_many :items, dependent: :destroy
   accepts_nested_attributes_for :items, allow_destroy: true, reject_if: proc { |attributes| attributes["quantity"].blank? }
+  validates :items, presence: true, if: Proc.new {|a| a.comments.blank?}
 
   validates :partner, presence: true
 

--- a/app/models/partner_request.rb
+++ b/app/models/partner_request.rb
@@ -3,7 +3,7 @@ class PartnerRequest < ApplicationRecord
 
   has_many :items, dependent: :destroy
   accepts_nested_attributes_for :items, allow_destroy: true, reject_if: proc { |attributes| attributes["quantity"].blank? }
-  validates :items, presence: true, if: Proc.new {|a| a.comments.blank?}
+  validates :items, presence: true, if: proc { |a| a.comments.blank? }
 
   validates :partner, presence: true
 


### PR DESCRIPTION
Fixed issue so that it validates taht a partner request only has items if it has no comments